### PR TITLE
Add system config editor

### DIFF
--- a/pdfanalyze-vue/src/router/route.ts
+++ b/pdfanalyze-vue/src/router/route.ts
@@ -31,7 +31,22 @@ export const dynamicRoutes: Array<RouteRecordRaw> = [
       isKeepAlive: true,
       icon: 'HomeOutlined',
     },
-    children: [],
+    children: [
+      {
+        path: '/system/systemConfig',
+        name: 'systemConfig',
+        component: () => import('/@/views/system/systemConfig/index.vue'),
+        meta: {
+          title: 'SystemConfig',
+          isLink: '',
+          isHide: false,
+          isKeepAlive: true,
+          isAffix: false,
+          isIframe: false,
+          icon: 'SettingOutlined',
+        },
+      },
+    ],
   },
   {
     path: '/personal',

--- a/pdfanalyze-vue/src/stores/systemConfig.ts
+++ b/pdfanalyze-vue/src/stores/systemConfig.ts
@@ -22,6 +22,14 @@ export const SystemConfigStore = defineStore('SystemConfig', {
         console.log("retdata", this.systemConfig)
       });
     },
+    async saveSystemConfigs(data: any) {
+      await request({
+        url: '/api/system/system_config/save_content/',
+        method: 'put',
+        data,
+      });
+      await this.getSystemConfigs();
+    },
   },
   persist: {
     enabled: true,

--- a/pdfanalyze-vue/src/views/system/systemConfig/api.ts
+++ b/pdfanalyze-vue/src/views/system/systemConfig/api.ts
@@ -1,0 +1,19 @@
+import { request } from "/@/utils/service";
+
+export const apiPrefix = "/api/system/system_config/";
+
+export function GetList(query: any) {
+  return request({
+    url: apiPrefix,
+    method: "get",
+    params: query,
+  });
+}
+
+export function SaveContent(data: any) {
+  return request({
+    url: apiPrefix + "save_content/",
+    method: "put",
+    data,
+  });
+}

--- a/pdfanalyze-vue/src/views/system/systemConfig/index.vue
+++ b/pdfanalyze-vue/src/views/system/systemConfig/index.vue
@@ -1,0 +1,76 @@
+<template>
+  <div class="system-config-page">
+    <a-form
+      :model="formState"
+      label-col="{ span: 6 }"
+      wrapper-col="{ span: 12 }"
+    >
+      <a-form-item
+        v-for="item in configList"
+        :key="item.id"
+        :label="item.title"
+      >
+        <component
+          :is="getComponent(item.form_item_type)"
+          v-model:value="formState[item.key]"
+          v-model:checked="formState[item.key]"
+          :options="item.data_options || []"
+        />
+      </a-form-item>
+      <a-form-item>
+        <a-button type="primary" @click="handleSave">保存</a-button>
+      </a-form-item>
+    </a-form>
+  </div>
+</template>
+
+<script setup lang="ts" name="systemConfig">
+import { ref, reactive, onMounted } from "vue";
+import { GetList, SaveContent } from "./api";
+import { successNotification } from "/@/utils/message";
+import { SystemConfigStore } from "/@/stores/systemConfig";
+
+const configList = ref<any[]>([]);
+const formState = reactive<Record<string, any>>({});
+
+function getComponent(type: number) {
+  switch (type) {
+    case 9:
+      return "a-switch";
+    case 4:
+      return "a-select";
+    default:
+      return "a-input";
+  }
+}
+
+async function fetchData() {
+  const res = await GetList({ parent__isnull: true });
+  configList.value = res.data || [];
+  configList.value.forEach((item) => {
+    formState[item.key] = item.value;
+  });
+}
+
+async function handleSave() {
+  const payload = configList.value.map((item) => ({
+    id: item.id,
+    key: item.key,
+    value: formState[item.key],
+  }));
+  const ret = await SaveContent(payload);
+  if (ret?.code === 2000) {
+    successNotification(ret.msg as string);
+    SystemConfigStore().getSystemConfigs();
+  }
+}
+
+onMounted(fetchData);
+</script>
+
+<style scoped>
+.system-config-page {
+  padding: 20px;
+  background: #fff;
+}
+</style>


### PR DESCRIPTION
## Summary
- add SystemConfigStore action for saving configs
- expose `/api/system/system_config/` via new api wrapper
- create SystemConfig view with simple edit form
- register `/system/systemConfig` route

## Testing
- `pnpm exec jest`

------
https://chatgpt.com/codex/tasks/task_e_6850e0a59380832c9ff59f99f36e6aaa